### PR TITLE
CPT-154 fix: enable set-commits only on commit workflow

### DIFF
--- a/.circleci/config.yml
+++ b/.circleci/config.yml
@@ -4,6 +4,8 @@ workflows:
   commit:
     jobs:
       - build:
+          context:
+            - enable-set-commits
           filters:
             branches:
               only:

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -46,7 +46,7 @@ exports.onCreateWebpackConfig = ({ stage, actions, getConfig }) => {
         authToken: process.env.SENTRY_AUTH_TOKEN,
         org: "pingcap",
         project: "community-website",
-        setCommits: {
+        setCommits: process.env.ENABLE_SET_COMMITS === 'true' && {
           auto: true,
         },
         release: process.env.SENTRY_RELEASE,


### PR DESCRIPTION
Otherwise the scheduled `build` workflow will call `sentry-cli set-commits`, which might overwrite the last release and break commits tracking. 