### PR TITLE
chore: add nodejs minimum version requirement

### DIFF
--- a/package.json
+++ b/package.json
@@ -67,7 +67,7 @@
     "react-intl": "^5.10.9",
     "shipit-cli": "5.3.0",
     "shipit-deploy": "5.3.0",
-    "shipit-shared": "4.4.2",
+    "shipit-shared": "4.4.2"
   },
   "engines": {
     "node": ">=14.0.0"

--- a/package.json
+++ b/package.json
@@ -67,6 +67,9 @@
     "react-intl": "^5.10.9",
     "shipit-cli": "5.3.0",
     "shipit-deploy": "5.3.0",
-    "shipit-shared": "4.4.2"
+    "shipit-shared": "4.4.2",
+  },
+  "engines": {
+    "node": ">=14.0.0"
   }
 }


### PR DESCRIPTION
optional chaining is supported after nodejs 14.