### PR TITLE
CPT-156 feat: share github avatar cache

### DIFF
--- a/package.json
+++ b/package.json
@@ -66,6 +66,7 @@
     "dayjs": "^1.10.1",
     "react-intl": "^5.10.9",
     "shipit-cli": "5.3.0",
-    "shipit-deploy": "5.3.0"
+    "shipit-deploy": "5.3.0",
+    "shipit-shared": "4.4.2"
   }
 }

--- a/shipitfile.js
+++ b/shipitfile.js
@@ -3,6 +3,7 @@
 // https://www.digitalocean.com/community/tutorials/how-to-automate-your-node-js-production-deployments-with-shipit-on-centos-7
 module.exports = (shipit) => {
   require('shipit-deploy')(shipit);
+  require('shipit-shared')(shipit);
 
   shipit.initConfig({
     default: {
@@ -19,6 +20,11 @@ module.exports = (shipit) => {
       shallowClone: false,
       branch: 'HEAD',
       copy: false,
+
+      shared: {
+        overwrite: true,
+        dirs: ['public/cache/github-avatar'],
+      },
     },
 
     production: {
@@ -29,7 +35,7 @@ module.exports = (shipit) => {
     },
   });
 
-  shipit.on('published', () => {
+  shipit.on('sharedEnd', () => {
     shipit.start('server:reload');
   });
 

--- a/yarn.lock
+++ b/yarn.lock
@@ -3926,7 +3926,7 @@ block-stream@*:
   dependencies:
     inherits "~2.0.0"
 
-bluebird@^3.0.5, bluebird@^3.5.5, bluebird@^3.7.2:
+bluebird@^3.0.5, bluebird@^3.0.6, bluebird@^3.5.5, bluebird@^3.7.2:
   version "3.7.2"
   resolved "https://registry.yarnpkg.com/bluebird/-/bluebird-3.7.2.tgz#9f229c15be272454ffa973ace0dbee79a1b0c36f"
   integrity sha512-XpNj6GDQzdfW+r2Wnn7xiSAd7TM3jzkxGXBGTtWKuSXv1xUV+azxAm8jdWZN06QTQk+2N2XB9jRDkvbmQmcRtg==
@@ -11117,7 +11117,7 @@ lodash.without@^4.4.0:
   resolved "https://registry.yarnpkg.com/lodash.without/-/lodash.without-4.4.0.tgz#3cd4574a00b67bae373a94b748772640507b7aac"
   integrity sha1-PNRXSgC2e643OpS3SHcmQFB7eqw=
 
-lodash@^4.0.0, lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.7.0, lodash@~4.17.10:
+lodash@^4.0.0, lodash@^4.12.0, lodash@^4.13.1, lodash@^4.17.10, lodash@^4.17.11, lodash@^4.17.14, lodash@^4.17.15, lodash@^4.17.19, lodash@^4.17.20, lodash@^4.17.21, lodash@^4.17.4, lodash@^4.17.5, lodash@^4.2.0, lodash@^4.2.1, lodash@^4.3.0, lodash@^4.6.1, lodash@^4.7.0, lodash@~4.17.10:
   version "4.17.21"
   resolved "https://registry.yarnpkg.com/lodash/-/lodash-4.17.21.tgz#679591c564c3bffaae8454cf0b3df370c3d6911c"
   integrity sha512-v2kDEe57lecTulaDIuNTPy3Ry4gLGJ6Z1O3vE1krgXZNrsQ+LFTGHVxVjcXPs17LhbZVGedAJv8XZ1tvj5FvSg==
@@ -11859,7 +11859,7 @@ mkdirp@^1.0.4:
   resolved "https://registry.yarnpkg.com/mkdirp/-/mkdirp-1.0.4.tgz#3eb5ed62622756d79a5f0e2a221dfebad75c2f7e"
   integrity sha512-vVqVZQyf3WLx2Shd0qJ9xuvqgAyKPLAiqITEtqW0oIUjzo3PePDd6fW9iFz30ef7Ysp/oiWqbhszeGWW2T6Gzw==
 
-moment@^2.21.0, moment@^2.24.0, moment@^2.25.3, moment@^2.27.0:
+moment@^2.12.0, moment@^2.21.0, moment@^2.24.0, moment@^2.25.3, moment@^2.27.0:
   version "2.29.1"
   resolved "https://registry.yarnpkg.com/moment/-/moment-2.29.1.tgz#b2be769fa31940be9eeea6469c075e35006fa3d3"
   integrity sha512-kHmoybcPV8Sqy59DwNDY3Jefr64lK/by/da0ViFcuA4DH0vQg5Q6Ze5VimxkfQNSC+Mls/Kx53s7TjP1RhFEDQ==
@@ -15639,7 +15639,35 @@ shipit-deploy@5.3.0:
     shipit-utils "^1.1.3"
     tmp-promise "^2.0.2"
 
-shipit-utils@^1.1.3:
+shipit-deploy@^2.1.2:
+  version "2.5.1"
+  resolved "https://registry.nlark.com/shipit-deploy/download/shipit-deploy-2.5.1.tgz#f9d40ce2583e7fe16ed80dbfeb424b00590dbc44"
+  integrity sha1-+dQM4lg+f+Fu2A2/60JLAFkNvEQ=
+  dependencies:
+    bluebird "^3.0.6"
+    chalk "^1.0.0"
+    lodash "^4.6.1"
+    mkdirp "^0.5.0"
+    moment "^2.12.0"
+    path2 "^0.1.0"
+    shipit-utils "^1.1.3"
+
+shipit-shared@4.4.2:
+  version "4.4.2"
+  resolved "https://registry.nlark.com/shipit-shared/download/shipit-shared-4.4.2.tgz#a20b5cc9859bd66ca87f2bad88396bc798f82a92"
+  integrity sha1-ogtcyYWb1myofyutiDlrx5j4KpI=
+  dependencies:
+    bluebird "^3.0.6"
+    chalk "^1.1.1"
+    lodash "^4.12.0"
+    mkdirp "^0.5.0"
+    path-is-absolute "^1.0.0"
+    path2 "^0.1.0"
+    shipit-deploy "^2.1.2"
+    shipit-utils "^1.0.2"
+    sprintf-js "^1.0.2"
+
+shipit-utils@^1.0.2, shipit-utils@^1.1.3:
   version "1.4.1"
   resolved "https://registry.nlark.com/shipit-utils/download/shipit-utils-1.4.1.tgz#f6c8b1cb4dacc3e2e7638b62ef9941be5c274e60"
   integrity sha1-9sixy02sw+LnY4ti75lBvlwnTmA=
@@ -15984,7 +16012,7 @@ split-string@^3.0.1, split-string@^3.0.2:
   dependencies:
     extend-shallow "^3.0.0"
 
-sprintf-js@^1.0.3:
+sprintf-js@^1.0.2, sprintf-js@^1.0.3:
   version "1.1.2"
   resolved "https://registry.yarnpkg.com/sprintf-js/-/sprintf-js-1.1.2.tgz#da1765262bf8c0f571749f2ad6c26300207ae673"
   integrity sha512-VE0SOVEHCk7Qc8ulkWw3ntAzXuqf7S2lvwQaDLRnUeIEaKNQJzV6BwmLKhOqT61aGhfUMrXeaBk+oDGCzvhcug==


### PR DESCRIPTION
Currently the shipis.js-based deployment use a different directory
for each release, which leaves no space for the cache event to run.