### PR TITLE
CP-169 fix: persist markdown-pages parent directory

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -69,9 +69,5 @@ yarn-error.log
 # Yarn Integrity file
 .yarn-integrity
 
-
-# ignore the downloaded markdown file
-markdown-pages/
-
 # Custom
 yarn.lock

--- a/markdown-pages/.gitignore
+++ b/markdown-pages/.gitignore
@@ -1,0 +1,4 @@
+# Ignore everything in this directory
+*
+# Except this file
+!.gitignore


### PR DESCRIPTION
CP-169: The reason of the building failure is that the markdown-pages dir is not always present due to network error. This PR persists the parent directory while ignores everything in it.